### PR TITLE
fix: center text in bio links with icons

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -39,7 +39,8 @@ import { Content as BioContent } from './bio.md';
 
 :global(a) {
   display: flex;
-  align-items: center;
+  position: relative;
+  justify-content: center;
   padding: 1rem;
   background-color: #d1d5db;
   border-radius: 8px;
@@ -56,7 +57,8 @@ import { Content as BioContent } from './bio.md';
 }
 
 :global(a i) {
-  margin-right: 15px;
+  position: absolute;
+  left: 1rem;
   font-size: 1.2em;
   width: 20px;
   text-align: center;
@@ -64,7 +66,6 @@ import { Content as BioContent } from './bio.md';
 }
 
 :global(a span) {
-  flex-grow: 1;
   text-align: center;
 }
 


### PR DESCRIPTION
### Problem
Text in bio links appears off-center when icons are present because icons occupy space in the flex layout, pushing text to the right.

### Solution
- Position icons absolutely (removed from flex flow)
- Use `justify-content: center` on link containers for proper centering
- Simplify span styling (removed unnecessary `flex-grow`)

### Testing
- Text properly centered in all bio links
- Icon hover colors work correctly
- Link hover effects functional
- No breaking changes

**Files changed:** `src/pages/index.astro`